### PR TITLE
Return

### DIFF
--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -162,7 +162,7 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
     } else {
-      this.setOutput(true, null);
+      this.setOutput(true, 'Number');
       if (this.getReturn() === Blockly.PROCEDURES_CALL_TYPE_BOOLEAN) {
         this.setOutputShape(Blockly.OUTPUT_SHAPE_HEXAGONAL);
       } else {

--- a/blocks_vertical/procedures.js
+++ b/blocks_vertical/procedures.js
@@ -162,10 +162,11 @@ Blockly.ScratchBlocks.ProcedureUtils.updateDisplay_ = function() {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
     } else {
-      this.setOutput(true, 'Number');
       if (this.getReturn() === Blockly.PROCEDURES_CALL_TYPE_BOOLEAN) {
+        this.setOutput(true, null);
         this.setOutputShape(Blockly.OUTPUT_SHAPE_HEXAGONAL);
       } else {
+        this.setOutput(true, 'Number');
         this.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
       }
     }

--- a/core/connection.js
+++ b/core/connection.js
@@ -222,8 +222,7 @@ Blockly.Connection.prototype.connect_ = function(childConnection) {
 
   if (
     Blockly.Events.isEnabled() &&
-    !childBlock.isInsertionMarker() &&
-    Blockly.Procedures.blockContainsReturn(childBlock)
+    !childBlock.isInsertionMarker()
   ) {
     childBlock.workspace.procedureReturnsChanged();
   }
@@ -599,8 +598,7 @@ Blockly.Connection.prototype.disconnectInternal_ = function(parentBlock,
 
   if (
     Blockly.Events.isEnabled() &&
-    !childBlock.isInsertionMarker() &&
-    Blockly.Procedures.blockContainsReturn(childBlock)
+    !childBlock.isInsertionMarker()
   ) {
     childBlock.workspace.procedureReturnsChanged();
   }

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -714,12 +714,10 @@ Blockly.WorkspaceSvg.prototype.processProcedureReturnsChanged = function() {
     var block = topBlocks[i];
     if (!block.getNextBlock() && block.type === Blockly.PROCEDURES_CALL_BLOCK_TYPE) {
       var procCode = block.getProcCode();
-      var actuallyReturns = Blockly.Procedures.procedureContainsReturn(procCode, this);
-
-      if (actuallyReturns && block.getReturn() === Blockly.PROCEDURES_CALL_TYPE_STATEMENT) {
-        Blockly.Procedures.changeReturnType(block, Blockly.PROCEDURES_CALL_TYPE_REPORTER);
-      } else if (!actuallyReturns && block.getReturn() !== Blockly.PROCEDURES_CALL_TYPE_STATEMENT) {
-        Blockly.Procedures.changeReturnType(block, Blockly.PROCEDURES_CALL_TYPE_STATEMENT);
+      var actuallyReturns = Blockly.Procedures.procedureContainsReturnType(procCode, this);
+      
+      if (actuallyReturns !== block.getReturn()) {
+        Blockly.Procedures.changeReturnType(block, actuallyReturns);
       }
     }
   }


### PR DESCRIPTION
I made a significant adjustment to the behavior of custom reporters for the local Scratch instance I use in classrooms. I don't know if this is desirable in TurboWarp, but I wanted to offer the change back upstream.

I did my best to maintain code quality, but I'm not a professional developer, so I apologize if some cleanup is needed.

### Resolves

Not Applicable. 

### Proposed Changes

If every return block connected to a block definition returns a boolean (as in, the `_` in every `return _` is a hexagon block), the call block will itself become hexagon-shaped, and able to be dropped in boolean inputs.

Block definitions with mixed return types will be ovals. Non-boolean "oval" call blocks cannot be dropped into boolean inputs.

![Screen Shot 2023-07-12 at 3 16 52 PM](https://github.com/TurboWarp/scratch-blocks/assets/4484096/954ab462-1a46-4f15-9a9a-c6a48da5039d)

### Reason for Changes

In TurboWarp's current `return` experiment, it is impossible to create boolean hexagonal reporters. As a workaround, TurboWarp allows non-boolean custom reporters to be dropped into boolean inputs, but this runs somewhat counter to how Scratch's type system is supposed to work<sup>†</sup>. I rely on the shape system when I teach elementary school students.

### Implementation Notes

In order to make this work, I set `Blockly.Procedures.blockContainsReturn` to run on every block connection/disconnection. I don't love this, but it was the best I could get working on my own. The function is already debounced, and I don't think it's doing anything resource intensive?

However, this has one notable side effect. If you:
1. Attach a call block to a larger script.
2. Add or remove a `return` from the block definition. (For usability reasons, the instance of the call block you already attached will not change shape.)
3. Detach the call block you attached previously.

...the call block will snap to its updated shape the moment it is detached. As it happens, I _greatly_ prefer this behavior anyway.

### Test Coverage

Tested manually. (And not _super_ extensively, but I'm relatively confident nothing will break.)

---

<sup>† Vanilla Scratch does allow `item _ of list` and `item # of _ in list` to be dropped into boolean inputs, but I think this is also kind of bad. It runs counter to the behavior of every other block.</sup>