### PR TITLE
Fix building on Windows or with Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ python_compressed.js
 /*compiler*.jar
 /local_blockly_compressed_vertical.js
 /chromedriver
+# --flagfiles used on Windows
+/*.config

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 Requires Node.js (`node`), Python (`python3`), and Java (`java`). It is known to work in these environments but should work in others:
 
  - Windows 10, Python 3.11.7 (Microsoft Store), Node.js 20.10.0 (nodejs.org installer), Java 11 (Temurin-11.0.21+9)
-
-Python 3.12 currently does not work.
+ - Windows 10, Python 3.12.1 (Microsoft Store), Node.js 20.10.0 (nodejs.org installer), Java 11 (Temurin-11.0.21+9)
 
 Install dependencies:
 
@@ -18,9 +17,9 @@ Install dependencies:
 npm ci
 ```
 
-The playground to use for local testing is tests/vertical_playground.html.
+Open tests/vertical_playground.html in a browser for local testing. You don't need to rebuild compressed versions for most changes.
 
-To build, run:
+To re-build compressed versions, run:
 
 ```sh
 npm run prepublish

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 ## Local development
 
+Requires Node.js (`node`), Python (`python3`), and Java (`java`). It is known to work in these environments but should work in others:
+
+ - Windows 10, Python 3.11.7 (Microsoft Store), Node.js 20.10.0 (nodejs.org installer), Java 11 (Temurin-11.0.21+9)
+
+Python 3.12 currently does not work.
+
 Install dependencies:
 
 ```sh
@@ -20,7 +26,7 @@ To build, run:
 npm run prepublish
 ```
 
-requires Python (2 or 3). scratch-gui development server must be restarted to update linked scratch-blocks.
+scratch-gui development server must be restarted to update linked scratch-blocks.
 
 <!--
 #### Scratch Blocks is a library for building creative computing interfaces.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 ## Local development
 
-Requires Node.js (`node`), Python (`python3`), and Java (`java`). It is known to work in these environments but should work in others:
+Requires Node.js (`node`), Python (`python3`), and Java (`java`). It is known to work in these environments but should work in many others:
 
- - Windows 10, Python 3.11.7 (Microsoft Store), Node.js 20.10.0 (nodejs.org installer), Java 11 (Temurin-11.0.21+9)
  - Windows 10, Python 3.12.1 (Microsoft Store), Node.js 20.10.0 (nodejs.org installer), Java 11 (Temurin-11.0.21+9)
+ - macOS 14.2.1, Python 3.11.6 (Apple), Node.js 20.10.0 (installed manually), Java 21 (Temurin-21.0.1+12)
+ - Ubuntu 22.04, Python 3.10.12 (python3 package), Node.js 20.10.0 (installed manually), Java 11 (openjdk-11-jre package)
 
 Install dependencies:
 
@@ -17,7 +18,7 @@ Install dependencies:
 npm ci
 ```
 
-Open tests/vertical_playground.html in a browser for local testing. You don't need to rebuild compressed versions for most changes.
+Open tests/vertical_playground.html in a browser for development. You don't need to rebuild compressed versions for most changes. Open tests/vertical_playground_compressed.html instead to test if the compressed versions built properly.
 
 To re-build compressed versions, run:
 

--- a/build.py
+++ b/build.py
@@ -595,28 +595,17 @@ if __name__ == "__main__":
 
     print("Using local compiler: %s ...\n" % CLOSURE_COMPILER_NPM)
   except (ImportError, AssertionError):
-    print("Using remote compiler: closure-compiler.appspot.com ...\n")
-
-    try:
-      closure_dir = CLOSURE_DIR
-      closure_root = CLOSURE_ROOT
-      closure_library = CLOSURE_LIBRARY
-      closure_compiler = CLOSURE_COMPILER
-
-      calcdeps = import_path(os.path.join(
-          closure_root, closure_library, "closure", "bin", "calcdeps.py"))
-    except ImportError:
-      if os.path.isdir(os.path.join(os.path.pardir, "closure-library-read-only")):
-        # Dir got renamed when Closure moved from Google Code to GitHub in 2014.
-        print("Error: Closure directory needs to be renamed from"
-              "'closure-library-read-only' to 'closure-library'.\n"
-              "Please rename this directory.")
-      elif os.path.isdir(os.path.join(os.path.pardir, "google-closure-library")):
-        print("Error: Closure directory needs to be renamed from"
-             "'google-closure-library' to 'closure-library'.\n"
-             "Please rename this directory.")
-      else:
-        print("""Error: Closure not found.  Read this:
+    if os.path.isdir(os.path.join(os.path.pardir, "closure-library-read-only")):
+      # Dir got renamed when Closure moved from Google Code to GitHub in 2014.
+      print("Error: Closure directory needs to be renamed from"
+            "'closure-library-read-only' to 'closure-library'.\n"
+            "Please rename this directory.")
+    elif os.path.isdir(os.path.join(os.path.pardir, "google-closure-library")):
+      print("Error: Closure directory needs to be renamed from"
+            "'google-closure-library' to 'closure-library'.\n"
+            "Please rename this directory.")
+    else:
+      print("""Error: Closure not found. Usually this means 'npm ci' failed. Try running it again? More resources:
   developers.google.com/blockly/guides/modify/web/closure""")
       sys.exit(1)
 

--- a/build.py
+++ b/build.py
@@ -116,7 +116,7 @@ window.BLOCKLY_DIR = (function() {
   if (!isNodeJS) {
     // Find name of current directory.
     var scripts = document.getElementsByTagName('script');
-    var re = new RegExp('(.+)[\/]blockly_uncompressed(_vertical|_horizontal|)\.js$');
+    var re = new RegExp('(.+)[\\/]blockly_uncompressed(_vertical|_horizontal|)\\.js$');
     for (var i = 0, script; script = scripts[i]; i++) {
       var match = re.exec(script.src);
       if (match) {
@@ -451,12 +451,12 @@ class Gen_compressed(threading.Thread):
       # The Closure Compiler preserves these.
       LICENSE = re.compile("""/\\*
 
- [\w ]+
+ [\\w ]+
 
  Copyright \\d+ Google Inc.
  https://developers.google.com/blockly/
 
- Licensed under the Apache License, Version 2.0 \(the "License"\);
+ Licensed under the Apache License, Version 2.0 \\(the "License"\\);
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 


### PR DESCRIPTION
 - Fix windows builds with something similar to https://github.com/scratchfoundation/scratch-blocks/pull/2138 (--flagfile)
 - Fix build on Python 3.12 (need to join() child threads to prevent main thread from shutting down)
 - Never try to use remote compilation as the server shut down a while ago
 - Update README.md with some example known-working environments