### PR TITLE
Shadow Arguments: Add Shadow Arguments (ScratchBlocks Part)

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -123,6 +123,12 @@ Blockly.Block = function(workspace, prototypeName, opt_id) {
 
   /**
    * @type {boolean}
+   * @private
+   */
+  this.isShadowArgument_ = false;
+
+  /**
+   * @type {boolean}
    * @protected
    */
   this.collapsed_ = false;

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -84,7 +84,7 @@ Blockly.scratchBlocksUtils.changeObscuredShadowIds = function(block) {
  */
 Blockly.scratchBlocksUtils.isShadowArgumentReporter = function(block) {
   return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
-      block.type == 'argument_reporter_string_number' || block.isShadowArgument));
+      block.type == 'argument_reporter_string_number' || block.isShadowArgument_));
 };
 
 /**

--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -84,7 +84,7 @@ Blockly.scratchBlocksUtils.changeObscuredShadowIds = function(block) {
  */
 Blockly.scratchBlocksUtils.isShadowArgumentReporter = function(block) {
   return (block.isShadow() && (block.type == 'argument_reporter_boolean' ||
-      block.type == 'argument_reporter_string_number'));
+      block.type == 'argument_reporter_string_number' || block.isShadowArgument));
 };
 
 /**


### PR DESCRIPTION
Add Shadow Arguments from More Control; an argument that's duplicated when dragged as a shadow block.

![image](https://github.com/TurboWarp/scratch-vm/assets/127533508/d26773c8-f852-470b-bc6b-2e7ef60d17e4)

Circumvents the need for nasty override scripts.