### PR TITLE
Remove block type checking ( see #12 )

### DIFF
--- a/core/connection.js
+++ b/core/connection.js
@@ -347,8 +347,6 @@ Blockly.Connection.prototype.checkConnection_ = function(target) {
     case Blockly.Connection.REASON_DIFFERENT_WORKSPACES:
       // Usually this means one block has been deleted.
       throw 'Blocks not on same workspace.';
-    case Blockly.Connection.REASON_WRONG_TYPE:
-      throw 'Attempt to connect incompatible types.';
     case Blockly.Connection.REASON_TARGET_NULL:
       throw 'Target connection is null.';
     case Blockly.Connection.REASON_CHECKS_FAILED:

--- a/core/connection.js
+++ b/core/connection.js
@@ -60,7 +60,7 @@ Blockly.Connection = function(source, type) {
  */
 Blockly.Connection.CAN_CONNECT = 0;
 Blockly.Connection.REASON_SELF_CONNECTION = 1;
-Blockly.Connection.REASON_WRONG_TYPE = 2;
+Blockly.Connection.REASON_WRONG_TYPE = 2; // this should not be used if i did it correctly
 Blockly.Connection.REASON_TARGET_NULL = 3;
 Blockly.Connection.REASON_CHECKS_FAILED = 4;
 Blockly.Connection.REASON_DIFFERENT_WORKSPACES = 5;
@@ -309,8 +309,6 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
   }
   if (blockA && blockA == blockB) {
     return Blockly.Connection.REASON_SELF_CONNECTION;
-  } else if (target.type != Blockly.OPPOSITE_TYPE[this.type]) {
-    return Blockly.Connection.REASON_WRONG_TYPE;
   } else if (blockA && blockB && blockA.workspace !== blockB.workspace) {
     return Blockly.Connection.REASON_DIFFERENT_WORKSPACES;
   } else if (!this.checkType_(target)) {

--- a/core/connection.js
+++ b/core/connection.js
@@ -60,7 +60,7 @@ Blockly.Connection = function(source, type) {
  */
 Blockly.Connection.CAN_CONNECT = 0;
 Blockly.Connection.REASON_SELF_CONNECTION = 1;
-Blockly.Connection.REASON_WRONG_TYPE = 2; // this should not be used if i did it correctly
+Blockly.Connection.REASON_WRONG_TYPE = 2;
 Blockly.Connection.REASON_TARGET_NULL = 3;
 Blockly.Connection.REASON_CHECKS_FAILED = 4;
 Blockly.Connection.REASON_DIFFERENT_WORKSPACES = 5;
@@ -311,6 +311,8 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
     return Blockly.Connection.REASON_SELF_CONNECTION;
   } else if (blockA && blockB && blockA.workspace !== blockB.workspace) {
     return Blockly.Connection.REASON_DIFFERENT_WORKSPACES;
+  } else if (target.type != Blockly.OPPOSITE_TYPE[this.type]) {
+    return Blockly.Connection.REASON_WRONG_TYPE;
   } else if (!this.checkType_(target)) {
     return Blockly.Connection.REASON_CHECKS_FAILED;
   } else if (blockA.isShadow() && !blockB.isShadow()) {

--- a/core/connection.js
+++ b/core/connection.js
@@ -287,6 +287,11 @@ Blockly.Connection.prototype.isConnected = function() {
 };
 
 /**
+ * Disables tyoe checking.
+ */
+Blockly.Connection.prototype.disableTypeChecking = false;
+
+/**
  * Checks whether the current connection can connect with the target
  * connection.
  * @param {Blockly.Connection} target Connection to check compatibility with.
@@ -312,6 +317,7 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
   } else if (blockA && blockB && blockA.workspace !== blockB.workspace) {
     return Blockly.Connection.REASON_DIFFERENT_WORKSPACES;
   } else if (target.type != Blockly.OPPOSITE_TYPE[this.type]) {
+    if (this.disableTypeChecking) return Blockly.Connection.CAN_CONNECT;
     return Blockly.Connection.REASON_WRONG_TYPE;
   } else if (!this.checkType_(target)) {
     return Blockly.Connection.REASON_CHECKS_FAILED;

--- a/core/connection.js
+++ b/core/connection.js
@@ -287,11 +287,6 @@ Blockly.Connection.prototype.isConnected = function() {
 };
 
 /**
- * Disables tyoe checking.
- */
-Blockly.Connection.prototype.disableTypeChecking = false;
-
-/**
  * Checks whether the current connection can connect with the target
  * connection.
  * @param {Blockly.Connection} target Connection to check compatibility with.
@@ -317,7 +312,6 @@ Blockly.Connection.prototype.canConnectWithReason_ = function(target) {
   } else if (blockA && blockB && blockA.workspace !== blockB.workspace) {
     return Blockly.Connection.REASON_DIFFERENT_WORKSPACES;
   } else if (target.type != Blockly.OPPOSITE_TYPE[this.type]) {
-    if (this.disableTypeChecking) return Blockly.Connection.CAN_CONNECT;
     return Blockly.Connection.REASON_WRONG_TYPE;
   } else if (!this.checkType_(target)) {
     return Blockly.Connection.REASON_CHECKS_FAILED;


### PR DESCRIPTION
## Moved to #12 due to me accidentally deleting the og repo
https://github.com/TurboWarp/scratch-blocks/pull/12

### Resolves

![image](https://github.com/TurboWarp/scratch-blocks/assets/135030944/8b5e3188-0531-426e-906d-bc5cb4ddf401)
![image](https://github.com/TurboWarp/scratch-blocks/assets/135030944/ee9eb315-8e7d-4f7b-81f5-7a1cbbf30bba)


### Proposed Changes

Removes type checking on "existing connections" (type checking for reporters so invalid parent and stuff will still happen)

### Reason for Changes

see first image

### Test Coverage

no tests, sorry :(
( i did test with a patch if you want it )