### PR TITLE
Expose "goog"

### DIFF
--- a/core/blockly.js
+++ b/core/blockly.js
@@ -616,3 +616,4 @@ if (!goog.global['Blockly']) {
   goog.global['Blockly'] = {};
 }
 goog.global['Blockly']['getMainWorkspace'] = Blockly.getMainWorkspace;
+goog.global['Blockly']['goog'] = goog;


### PR DESCRIPTION
### Resolves

https://discord.com/channels/837024174865776680/1193001099272138762

### Proposed Changes

Exposes goog on Blockly (ScratchBlocks)

### Reason for Changes

This will allow extension developers to access the "goog" variable.

### Test Coverage

No need :woman_shrugging: 
