### PR TITLE
Make field cursors reflect the entire click target area instead of just the field group

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -296,11 +296,11 @@ Blockly.Field.prototype.updateEditable = function() {
   if (this.sourceBlock_.isEditable()) {
     Blockly.utils.addClass(group, 'blocklyEditableText');
     Blockly.utils.removeClass(group, 'blocklyNonEditableText');
-    this.fieldGroup_.style.cursor = this.CURSOR;
+    this.getClickTarget_().style.cursor = this.CURSOR;
   } else {
     Blockly.utils.addClass(group, 'blocklyNonEditableText');
     Blockly.utils.removeClass(group, 'blocklyEditableText');
-    this.fieldGroup_.style.cursor = '';
+    this.getClickTarget_().style.cursor = '';
   }
 };
 


### PR DESCRIPTION
### Proposed Changes

Not really a bug, more of a teensy tiny quality of life improvement proposal. Basically it just applies `this.CURSOR` set on fields to apply to the entire click target instead of just the field group.

Before:
![before](https://github.com/user-attachments/assets/1f04fc2c-5e68-4aa6-8e93-988a5187a916)
After:
![after](https://github.com/user-attachments/assets/44aade67-3a11-468e-8ae5-8d07e487dad5)


### Reason for Changes

This makes the field's cursor reflect the actual area where it's clickable; so if your cursor turns into a text cursor you now know that you're hovering over the text field and will focus it if you click.

### Test Coverage

Not really tested (aside from trying it out in the playground).

<sub>This pull request was made on behalf of the entire NitroBolt project. /j (more specifically, Cubester requested me to upstream this one change)</sub>