### PR TITLE
Adjust angle dropdown color to match parent block

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -788,9 +788,7 @@ Blockly.Css.CONTENT = [
   '}',
 
   '.blocklyAngleCircle {',
-    'stroke: ' + Blockly.Colours.motion.tertiary + ';',
     'stroke-width: 1;',
-    'fill: ' + Blockly.Colours.motion.secondary + ';',
   '}',
 
   '.blocklyAngleCenterPoint {',

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -175,6 +175,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.DropDownDiv.clearContent();
   var div = Blockly.DropDownDiv.getContentDiv();
   // Build the SVG DOM.
+  const srcBlock = this.sourceBlock_.parentBlock_;
   var svg = Blockly.utils.createSvgElement('svg', {
     'xmlns': 'http://www.w3.org/2000/svg',
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
@@ -186,6 +187,8 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.utils.createSvgElement('circle', {
     'cx': Blockly.FieldAngle.HALF, 'cy': Blockly.FieldAngle.HALF,
     'r': Blockly.FieldAngle.RADIUS,
+    'fill': srcBlock.getColourSecondary(),
+    'stroke': srcBlock.getColourTertiary(),
     'class': 'blocklyAngleCircle'
   }, svg);
   this.gauge_ = Blockly.utils.createSvgElement('path',
@@ -245,10 +248,12 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
       'xlink:href',
       Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldAngle.ARROW_SVG_PATH
   );
+  const blockHSL = goog.color.hexToHsl(srcBlock.getColour());
+  // -214.86 stems from the blue hue in 'Blockly.FieldAngle.ARROW_SVG_PATH'
+  this.arrowSvg_.setAttribute("filter", `hue-rotate(${-214.86 + blockHSL[0]}deg) saturate(${blockHSL[1]}) brightness(${blockHSL[2] * 1.8})`);
 
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.parentBlock_.getColour(),
-      this.sourceBlock_.getColourTertiary());
-  Blockly.DropDownDiv.setCategory(this.sourceBlock_.parentBlock_.getCategory());
+  Blockly.DropDownDiv.setColour(srcBlock.getColour(), this.sourceBlock_.getColourTertiary());
+  Blockly.DropDownDiv.setCategory(srcBlock.getCategory());
   Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
 
   this.mouseDownWrapper_ =

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -137,9 +137,22 @@ Blockly.FieldAngle.RADIUS = Blockly.FieldAngle.HALF
 Blockly.FieldAngle.CENTER_RADIUS = 2;
 
 /**
- * Path to the arrow svg icon.
+ * SVG path data for arrow icon.
  */
-Blockly.FieldAngle.ARROW_SVG_PATH = 'icons/arrow.svg';
+Blockly.FieldAngle.ARROW_SVG_PATH_DATA =
+    'M 0.0189 -1.3178' +
+    ' L -4.4901 -0.5663' +
+    ' C -4.7532 -0.5224 -4.9811 -0.2606 -4.9811 0.0156' +
+    ' C -4.9811 0.2836 -4.7613 0.5522 -4.4901 0.5974' +
+    ' L 0.0189 1.3489' +
+    ' L 0.0189 3.0185' +
+    ' C 0.0189 3.5625 0.3833 3.752 0.8327 3.4269' +
+    ' L 4.641 0.6721' +
+    ' C 5.0982 0.3414 5.0957 -0.1853 4.6527 -0.5168' +
+    ' L 0.821 -3.3842' +
+    ' C 0.3756 -3.7175 0.0189 -3.5381 0.0189 -2.9874' +
+    ' L 0.0189 -1.3178' +
+    ' Z';
 
 /**
  * Clean up this FieldAngle, as well as the inherited FieldTextInput.
@@ -234,27 +247,17 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
     'r': Blockly.FieldAngle.HANDLE_RADIUS,
     'class': 'blocklyAngleDragHandle'
   }, this.handle_);
-  this.arrowSvg_ = Blockly.utils.createSvgElement('image',
+  this.arrowSvg_ = Blockly.utils.createSvgElement('path',
       {
         'width': Blockly.FieldAngle.ARROW_WIDTH,
         'height': Blockly.FieldAngle.ARROW_WIDTH,
         'x': -Blockly.FieldAngle.ARROW_WIDTH / 2,
         'y': -Blockly.FieldAngle.ARROW_WIDTH / 2,
-        'class': 'blocklyAngleDragArrow'
+        'class': 'blocklyAngleDragArrow',
+        'fill': parentBlock.getColour(),
+        'd': Blockly.FieldAngle.ARROW_SVG_PATH_DATA
       },
       this.handle_);
-  this.arrowSvg_.setAttributeNS(
-      'http://www.w3.org/1999/xlink',
-      'xlink:href',
-      Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldAngle.ARROW_SVG_PATH
-  );
-  var blockHSL = goog.color.hexToHsl(parentBlock.getColour());
-  // -214.86 stems from the blue hue in 'Blockly.FieldAngle.ARROW_SVG_PATH'
-  this.arrowSvg_.setAttribute(
-      'filter',
-      'hue-rotate(' + (-214.86 + blockHSL[0]) + 'deg) saturate(' +
-          blockHSL[1] + ') brightness(' + (blockHSL[2] * 1.8) + ')'
-  );
 
   Blockly.DropDownDiv.setColour(parentBlock.getColour(), this.sourceBlock_.getColourTertiary());
   Blockly.DropDownDiv.setCategory(parentBlock.getCategory());

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -175,7 +175,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.DropDownDiv.clearContent();
   var div = Blockly.DropDownDiv.getContentDiv();
   // Build the SVG DOM.
-  const srcBlock = this.sourceBlock_.parentBlock_;
+  const parentBlock = this.sourceBlock_.parentBlock_;
   var svg = Blockly.utils.createSvgElement('svg', {
     'xmlns': 'http://www.w3.org/2000/svg',
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
@@ -187,8 +187,8 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.utils.createSvgElement('circle', {
     'cx': Blockly.FieldAngle.HALF, 'cy': Blockly.FieldAngle.HALF,
     'r': Blockly.FieldAngle.RADIUS,
-    'fill': srcBlock.getColourSecondary(),
-    'stroke': srcBlock.getColourTertiary(),
+    'fill': parentBlock.getColourSecondary(),
+    'stroke': parentBlock.getColourTertiary(),
     'class': 'blocklyAngleCircle'
   }, svg);
   this.gauge_ = Blockly.utils.createSvgElement('path',
@@ -248,12 +248,12 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
       'xlink:href',
       Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldAngle.ARROW_SVG_PATH
   );
-  const blockHSL = goog.color.hexToHsl(srcBlock.getColour());
+  const blockHSL = goog.color.hexToHsl(parentBlock.getColour());
   // -214.86 stems from the blue hue in 'Blockly.FieldAngle.ARROW_SVG_PATH'
   this.arrowSvg_.setAttribute("filter", `hue-rotate(${-214.86 + blockHSL[0]}deg) saturate(${blockHSL[1]}) brightness(${blockHSL[2] * 1.8})`);
 
-  Blockly.DropDownDiv.setColour(srcBlock.getColour(), this.sourceBlock_.getColourTertiary());
-  Blockly.DropDownDiv.setCategory(srcBlock.getCategory());
+  Blockly.DropDownDiv.setColour(parentBlock.getColour(), this.sourceBlock_.getColourTertiary());
+  Blockly.DropDownDiv.setCategory(parentBlock.getCategory());
   Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_);
 
   this.mouseDownWrapper_ =

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -175,7 +175,7 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
   Blockly.DropDownDiv.clearContent();
   var div = Blockly.DropDownDiv.getContentDiv();
   // Build the SVG DOM.
-  const parentBlock = this.sourceBlock_.parentBlock_;
+  var parentBlock = this.sourceBlock_.parentBlock_;
   var svg = Blockly.utils.createSvgElement('svg', {
     'xmlns': 'http://www.w3.org/2000/svg',
     'xmlns:html': 'http://www.w3.org/1999/xhtml',
@@ -248,9 +248,13 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
       'xlink:href',
       Blockly.mainWorkspace.options.pathToMedia + Blockly.FieldAngle.ARROW_SVG_PATH
   );
-  const blockHSL = goog.color.hexToHsl(parentBlock.getColour());
+  var blockHSL = goog.color.hexToHsl(parentBlock.getColour());
   // -214.86 stems from the blue hue in 'Blockly.FieldAngle.ARROW_SVG_PATH'
-  this.arrowSvg_.setAttribute("filter", `hue-rotate(${-214.86 + blockHSL[0]}deg) saturate(${blockHSL[1]}) brightness(${blockHSL[2] * 1.8})`);
+  this.arrowSvg_.setAttribute(
+      'filter',
+      'hue-rotate(' + (-214.86 + blockHSL[0]) + 'deg) saturate(' +
+          blockHSL[1] + ') brightness(' + (blockHSL[2] * 1.8) + ')'
+  );
 
   Blockly.DropDownDiv.setColour(parentBlock.getColour(), this.sourceBlock_.getColourTertiary());
   Blockly.DropDownDiv.setCategory(parentBlock.getCategory());


### PR DESCRIPTION
Other extensions can use the angle input, it should copy the color instead of using the motion colors:
Ported from PenguinMod
<img width="197" height="229" alt="Screenshot 2025-08-01 at 11 02 56 AM" src="https://github.com/user-attachments/assets/6709001c-9f25-493a-8586-d47eded34d6d" />
