### PR TITLE
Re-randomize block IDs on paste

### DIFF
--- a/core/scratch_blocks_utils.js
+++ b/core/scratch_blocks_utils.js
@@ -73,6 +73,23 @@ Blockly.scratchBlocksUtils.changeObscuredShadowIds = function(block) {
 };
 
 /**
+ * Recursively assign fresh IDs to blocks, in-place.
+ * @param {Element} xmlBlock The root XML
+ */
+Blockly.scratchBlocksUtils.changeCopiedBlockIds = function(xmlBlock) {
+  var tagName = xmlBlock.tagName && xmlBlock.tagName.toLowerCase();
+  if (tagName === 'block' || tagName === 'shadow') {
+    xmlBlock.setAttribute('id', Blockly.utils.genUid());
+  }
+  for (var i = 0; i < xmlBlock.childNodes.length; i++) {
+    var child = xmlBlock.childNodes[i];
+    if (child.nodeType === 1) {
+      Blockly.scratchBlocksUtils.changeCopiedBlockIds(child);
+    }
+  }
+};
+
+/**
  * Whether a block is both a shadow block and an argument reporter.  These
  * blocks have special behaviour in scratch-blocks: they're duplicated when
  * dragged, and they are rendered slightly differently from normal shadow

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1129,6 +1129,7 @@ Blockly.WorkspaceSvg.prototype.paste = function(xmlBlock) {
 Blockly.WorkspaceSvg.prototype.pasteBlock_ = function(xmlBlock) {
   Blockly.Events.disable();
   try {
+    Blockly.scratchBlocksUtils.changeCopiedBlockIds(xmlBlock);
     var block = Blockly.Xml.domToBlock(xmlBlock, this);
     // Scratch-specific: Give shadow dom new IDs to prevent duplicating on paste
     Blockly.scratchBlocksUtils.changeObscuredShadowIds(block);


### PR DESCRIPTION
May fix some general odd behaviors with the copy + paste

This would also resolve <!-- --> https://github.com/TurboWarp/scratch-gui/issues/1172 but leave the more underlying issue in there